### PR TITLE
test: DataJpaTest 실행시 table이 생성되지 않는 이슈 수정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,10 +29,10 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.9.8")
     implementation("io.jsonwebtoken:jjwt:0.9.1")
 
-    runtimeOnly("mysql:mysql-connector-java:5.1.6")
+    runtimeOnly("mysql:mysql-connector-java")
+    runtimeOnly("com.h2database:h2")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("com.h2database:h2:1.3.148")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/test/kotlin/com/sharefinancialledger/user/repository/UserRepositoryTest.kt
+++ b/src/test/kotlin/com/sharefinancialledger/user/repository/UserRepositoryTest.kt
@@ -1,0 +1,22 @@
+package com.sharefinancialledger.user.repository
+
+import com.sharefinancialledger.user.entity.User
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+
+@DataJpaTest
+class UserRepositoryTest {
+
+    @Autowired
+    lateinit var repository: UserRepository
+
+    @Test
+    fun `이메일로 유저를 조회할 수 있다`() {
+        repository.save(User(email = "lowell@naver.com", password = "password", name = "로웰"))
+
+        val result = repository.findFirstByEmail("lowell@naver.com")
+        assertThat(result).isPresent
+    }
+}

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -4,15 +4,19 @@ logging:
     org.hibernate.type: debug
 
 spring:
+  test:
+    database:
+      replace: none
   datasource:
-    url: jdbc:h2:mem:testdb;MODE=MYSQL
+    driver-class-name: org.h2.Driver
+    url: jdbc:h2:mem:testdb
     hikari:
       minimum-idle: 1
       maximum-pool-size: 1
-      driver-class-name: org.h2.Driver
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     show-sql: true
     properties:
       hibernate.format_sql: true
       hibernate.hbm2ddl.auto: create-drop
+    database: h2


### PR DESCRIPTION
이슈 원인
@DataJpaTest로 테스트시 mysql driver를 사용했는데, test application.yml에 spring.test.database.replace: none을 설정하지 않아 jdbc:h2:mem:testdb;MODE=MySQL 설정이 먹지 않아서 h2에서 mysql 쿼리를 처리하지 못함.
[참고](https://velog.io/@jwkim/spring-boot-datajpatest-error)
```
결론적으로, @DataJpaTest의 @AutoConfigureTestDatabase가 config에 있는 H2 DB가 아닌
, EmbeddedDatabaseConnection에 설정된 임시의 H2 DB를 호출해서 문제가 발생한 것이었다. 이 때 H2의 url은

"jdbc:h2:mem:%s;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE", (url) -> url.contains(":h2:mem")
이렇게 설정되어 있다. 여기에 MODE=MySQL이 없어서 MySQL 문법으로 쿼리를 날리면 오류가 발생한 것이다.
```

근본적인 원인
test 패키지 내의 application.yml에 @DataJpaTest에 mysql driver가 아닌 h2 driver를 사용하도록 설정해놓았는데 먹지 않음.
디버깅해보니 driver 설정은 main 패키지 내의 applicaiton.yml꺼를 사용했지만 url은 test 패키지 내의 application.yml 사용함.
이유를 찾아보니 main 패키지 내의 applicaiton.yml 의 설정을 test 패키지안의 application.yml로 완전히 교체하려면 둘의 path가 완전히 동일해야하는데, 실수로 main은 resources/config/applicaiton.yml, test는  resources/applicaiton.yml 로 되어있었음. 그래서 설정이 꼬인듯 

결론 
test의  application.yml의 path를 수정하고 spring.test.database.replace: none를 추가함
[ 참고](https://stackoverflow.com/questions/38711871/load-different-application-yml-in-springboot-test/38712718)
